### PR TITLE
switch N50 and L50

### DIFF
--- a/src/n50.cc
+++ b/src/n50.cc
@@ -145,8 +145,8 @@ int main(int argc, char** argv)
     {
         if( 2*length >= tot_length ) break;
         length += *rit;
-        N50++;
-        L50 = *rit;
+	N50 = *rit;
+        L50++;
     }
 
     cout << getBaseName(argv[1]) << " statistics:" << endl


### PR DESCRIPTION
The calculation of N50 and L50 were swapped in the n50.cc source and the results could be confusing. This pull request fixes this problem.